### PR TITLE
Add Django 2.2 support

### DIFF
--- a/django_db_views/management/commands/makeviewmigrations.py
+++ b/django_db_views/management/commands/makeviewmigrations.py
@@ -33,6 +33,10 @@ class Command(MakemigrationsCommand):
             help="Use this name for migration file(s).",
         )   # Working
         parser.add_argument(
+            '--no-header', action='store_false', dest='include_header',
+            help='Do not add header comments to new migration file(s).',
+        )
+        parser.add_argument(
             '--check', action='store_true', dest='check_changes',
             help='Exit with a non-zero status if model changes are missing migrations.',
         )   # we need that?
@@ -43,6 +47,7 @@ class Command(MakemigrationsCommand):
         self.dry_run = options['dry_run']
         self.merge = options['merge']
         self.migration_name = options['name']
+        self.include_header = options['include_header']
         check_changes = options['check_changes']
 
         # validation application labels


### PR DESCRIPTION
Without this I am getting this error when running `makeviewmigrations`:
```python
Traceback (most recent call last):
  File "./manage.py", line 22, in <module>
    main()
  File "./manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/usr/lib/python3/dist-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python3/dist-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/lib/python3/dist-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/lib/python3/dist-packages/django/core/management/base.py", line 364, in execute
    output = self.handle(*args, **options)
  File "/home/dmitry/upstream/django-db-views/django_db_views/management/commands/makeviewmigrations.py", line 85, in handle
    self.write_migration_files(changes)
  File "/usr/lib/python3/dist-packages/django/core/management/commands/makemigrations.py", line 196, in write_migration_files
    writer = MigrationWriter(migration, self.include_header)
AttributeError: 'Command' object has no attribute 'include_header'
```

See django/django#10743 where this change was added.