### PR TITLE
TransactionManagementError fix

### DIFF
--- a/django_db_views/autodetector.py
+++ b/django_db_views/autodetector.py
@@ -115,8 +115,8 @@ class ViewMigrationAutoDetector(MigrationAutodetector):
                 self.add_operation(
                     app_label,
                     ViewRunPython(
-                        ForwardViewMigration(new_view_definition, view_model._meta.db_table),
-                        BackwardViewMigration(current_view_definition, view_model._meta.db_table),
+                        ForwardViewMigration(new_view_definition.strip(";"), view_model._meta.db_table),
+                        BackwardViewMigration(current_view_definition.strip(";"), view_model._meta.db_table),
                         atomic=False
                     ),
                     dependencies=dependencies,

--- a/django_db_views/autodetector.py
+++ b/django_db_views/autodetector.py
@@ -116,7 +116,8 @@ class ViewMigrationAutoDetector(MigrationAutodetector):
                     app_label,
                     ViewRunPython(
                         ForwardViewMigration(new_view_definition, view_model._meta.db_table),
-                        BackwardViewMigration(current_view_definition, view_model._meta.db_table)
+                        BackwardViewMigration(current_view_definition, view_model._meta.db_table),
+                        atomic=False
                     ),
                     dependencies=dependencies,
                 )


### PR DESCRIPTION
```python

  File "/home/ryan/project/venv/lib/python3.7/site-packages/django_db_views/migration_functions.py", line 16, in __call__
    schema_editor.execute("DROP VIEW IF EXISTS %s;" % self.table_name)
  File "/home/ryan/project/venv/lib/python3.7/site-packages/django/db/backends/base/schema.py", line 127, in execute
    "Executing DDL statements while in a transaction on databases "
django.db.transaction.TransactionManagementError: Executing DDL statements while in a transaction on databases that can't perform a rollback is prohibited.

```

This will occur on Django 3