### PR TITLE
Fix previous view state computation

### DIFF
--- a/django_db_views/autodetector.py
+++ b/django_db_views/autodetector.py
@@ -131,7 +131,8 @@ class ViewMigrationAutoDetector(MigrationAutodetector):
         return view_definition.strip()
 
     def get_previous_view_definition_state(self, graph: MigrationGraph, app_label: str, for_table_name: str):
-        last_node = graph.leaf_nodes(app_label)[0]
+        nodes = graph.leaf_nodes(app_label)
+        last_node = nodes[0] if nodes else None
 
         while last_node:
             migration = graph.nodes[last_node]
@@ -148,7 +149,7 @@ class ViewMigrationAutoDetector(MigrationAutodetector):
                 last_node = app_parents[-1]
             else:   # if no parents mean we found initial migration
                 last_node = None
-        return None
+        return ""
 
     def get_current_view_definition_from_database(self, table_name: str)->str:
         """working only with postgres"""

--- a/django_db_views/management/commands/makeviewmigrations.py
+++ b/django_db_views/management/commands/makeviewmigrations.py
@@ -51,6 +51,7 @@ class Command(MakemigrationsCommand):
         check_changes = options['check_changes']
 
         # validation application labels
+        app_labels = set(app_labels)
         self.validate_applications(app_labels)
 
         # we don't check conflicts as regular makemigrations command.
@@ -89,9 +90,8 @@ class Command(MakemigrationsCommand):
         else:
             self.write_migration_files(changes)
 
-    def validate_applications(self, app_labels: list):
+    def validate_applications(self, app_labels: set):
         """it's copy paste from make migration command"""
-        app_labels = set(app_labels)
         has_bad_labels = False
         for app_label in app_labels:
             try:


### PR DESCRIPTION
* Consider the case where there are no leaf nodes.
* Return a string when no previous definitions are found instead of `None` to avoid attribute errors on NoneType.

Fixes BezBartek/django-db-views#7

* Fix exception, line 83, in handle: `AttributeError: 'tuple' object has no attribute 'pop'`. 