### PR TITLE
Make it possible to specify views dependencies manually

### DIFF
--- a/django_db_views/autodetector.py
+++ b/django_db_views/autodetector.py
@@ -209,6 +209,7 @@ class ViewMigrationAutoDetector(MigrationAutodetector):
                         if isinstance(base, six.string_types) and "." in base:
                             base_app_label, base_name = base.split(".", 1)
                             dependencies.append((base_app_label, base_name, None, True))
+                    dependencies += getattr(view_model, "dependencies", [])
                     self.add_operation(
                         app_label,
                         ViewRunPython(


### PR DESCRIPTION
When a view uses a column that was not present from the beginning, you want the auto-generated view migration depend on the migration that added the column. Otherwise the view migration would fail to apply.

This PR adds a possibility to specify the list of such columns manually, and Django will convert the list of columns to the list of migrations.

Example of how it can be used:
```python
from django.db.migrations.autodetector import OperationDependency
from django_db_views.db_view import DBView

class MyView(DBView):
    ...

    dependencies = [
        OperationDependency("articles", "ArticleAuthorship", "name", OperationDependency.Type.CREATE),
        OperationDependency("books", "Book", "series", OperationDependency.Type.CREATE),
    ]
```

On a related note, line 211 is broken in Django ≥ 5.1, since `dependencies` should be a list of `OperationDependency`, not a list of 4-element tuples (since django/django@7dd3e694db17bc34f9ce73e516f853ebd16e19e7). I can fix it in a separate PR if you want.